### PR TITLE
alert 가 opacity 에 가려서 안나오는 문제

### DIFF
--- a/static/css/namuvector.css
+++ b/static/css/namuvector.css
@@ -134,3 +134,6 @@ footer {
 .breadcrumb.link-nav > li {
     display: inline-block;
 }
+.fade.in {
+    opacity: 1 !important;
+}


### PR DESCRIPTION
.fade {
    opacity: 0;
    -webkit-transition: opacity .15s linear;
    -o-transition: opacity .15s linear;
    transition: opacity .15s linear;
}
opacity 가 0 이라 alert 가 안나옴. 원래 이런지는 모르겠지만
우선 리버티나 senwaka나 opacity: 1로 하는거 보고 추가함.

이 선언이 거슬린다면 bootstrap 에서 fade 자체를 빼도 됩니다.